### PR TITLE
Add Aliexpress reseller with cheapest metal case option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ A clone of the Watchy, sold on various platforms from probably various sellers, 
     - [AliExpress link](https://www.aliexpress.com/item/1005007684185170.html)
     - Has the cheapest option for an included anodised aluminium case w/ silicone strap (as of time of writing)
     - Battery is ok, but could be better
-    - TinyWatchy shows its battery as ~42-45% percent charged at max capacity
 - Banggood
   - One person bought and is satisfied
   - [A horrible long link](https://usa.banggood.com/Watchy-ESP32-Open-Source-E-Watch-WiFi-bluetooth-Programmable-Watch-E-Paper-Watch-with-Open-Source-Hardware-and-Software-p-2004157.html?af_force_deeplink=true&tags=direct&source_caller=api&pid=direct&is_retargeting=true&shortlink=ecydp3md&af_ad=-&deep_link_value=https%3A%2F%2Fm.banggood.com%2FWatchy-ESP32-Open-Source-E-Watch-WiFi-bluetooth-Programmable-Watch-E-Paper-Watch-with-Open-Source-Hardware-and-Software-p-2004157.html%3Futm_source%3Ddirect%26utm_medium%3Dnone%26utm_content%3D-%26utm_campaign%3Dnone_pps_copy&af_channel=none&c=-&cur_warehouse=CN)

--- a/README.md
+++ b/README.md
@@ -45,10 +45,16 @@ The rest of the repo is about those alternative clones, There is also infortmati
 
 ## Clones
 A clone of the Watchy, sold on various platforms from probably various sellers, but the manufacturer is probably the same.
-- Aliexpress seller, the first one that appeared, the most trusted in my opinion (The most people buught from him)
-  - Here is their Github repo for the "E-watch". There is nothing really there ;) - https://github.com/01Space/E-Watch
-  - Their aliexpress store: https://pl.aliexpress.com/store/912632218
-  - And the watchy on their store: https://pl.aliexpress.com/item/1005005209927318.html (It's the original manufacturer, others on Ali probably resell his watchy)
+- Aliexpress sellers
+  - the first one that appeared, the most trusted in my opinion (The most people buught from him)
+    - Here is their Github repo for the "E-watch". There is nothing really there ;) - https://github.com/01Space/E-Watch
+    - Their aliexpress store: https://pl.aliexpress.com/store/912632218
+    - And the watchy on their store: https://pl.aliexpress.com/item/1005005209927318.html (It's the original manufacturer, others on Ali probably resell his watchy)
+  - Another seller/reseller
+    - [AliExpress link](https://www.aliexpress.com/item/1005007684185170.html)
+    - Has the cheapest option for an included anodised aluminium case w/ silicone strap (as of time of writing)
+    - Battery is ok, but could be better
+    - TinyWatchy shows its battery as ~42-45% percent charged at max capacity
 - Banggood
   - One person bought and is satisfied
   - [A horrible long link](https://usa.banggood.com/Watchy-ESP32-Open-Source-E-Watch-WiFi-bluetooth-Programmable-Watch-E-Paper-Watch-with-Open-Source-Hardware-and-Software-p-2004157.html?af_force_deeplink=true&tags=direct&source_caller=api&pid=direct&is_retargeting=true&shortlink=ecydp3md&af_ad=-&deep_link_value=https%3A%2F%2Fm.banggood.com%2FWatchy-ESP32-Open-Source-E-Watch-WiFi-bluetooth-Programmable-Watch-E-Paper-Watch-with-Open-Source-Hardware-and-Software-p-2004157.html%3Futm_source%3Ddirect%26utm_medium%3Dnone%26utm_content%3D-%26utm_campaign%3Dnone_pps_copy&af_channel=none&c=-&cur_warehouse=CN)


### PR DESCRIPTION
Adds another AliExpress clone seller/reseller. This one is notable for providing the cheapest offer that includes a metal (anodised aluminium) case with a silicone strap, as of time of writing. Also includes some notes on its battery and peculiar behaviour with it and the TinyWatchy firmware.